### PR TITLE
fix: Format response text from server in example client implementation

### DIFF
--- a/examples/chatbots/typescript/src/server_clients/server.ts
+++ b/examples/chatbots/typescript/src/server_clients/server.ts
@@ -99,7 +99,7 @@ export abstract class Server {
 
         return {
           toolUseId: toolUseId,
-          content: [{ text: String(result) }],
+          content: [{ text: this.formatText(result) }],
           status: "success",
         };
       } catch (e) {
@@ -123,5 +123,17 @@ export abstract class Server {
 
     // This should never be reached due to the loop above
     throw new Error("Unexpected error in executeTool");
+  }
+
+  formatText(text: unknown): string {
+    if (typeof text === "string") {
+      return text;
+    } else if (Array.isArray(text)) {
+      return text.map((item) => this.formatText(item)).join("\n");
+    } else if (typeof text === "object" && text !== null) {
+      return JSON.stringify(text);
+    } else {
+      return String(text);
+    }
   }
 }


### PR DESCRIPTION
- `String(result)` often ends up calling down to toString on the object. When there is a large JSON object, it ends up with `object Object`
- This formats this, attempting to stringify objects, or eventually calling back down to String(text)

*Issue #, if available:*

*Description of changes:*

I was using the example here as a reference for implementing my own client, inside another Lambda function. The MCP Server it was calling was returning a large JSON object, which this client ends up parsing as `[object Object]`.
This change formats various possibilities. 

I know this is an example of a chat client here, but wanted to propose this, in case anyone else uses this as reference for their own clients.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
