### PR TITLE
fix: address high-severity bugs found during code audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ async with streamablehttp_client(
         tool_result = await session.call_tool("echo", {"message": "hello"})
 ```
 
-See a full example as part of the sample chatbot [here](examples/chatbots/python/server_clients/interactive_oauth.py).
+See a full example as part of the sample chatbot [here](examples/chatbots/python/interactive_oauth.py).
 
 </details>
 
@@ -303,7 +303,7 @@ const transport = new StreamableHTTPClientTransport(
 await client.connect(transport);
 ```
 
-See a full example as part of the sample chatbot [here](examples/chatbots/typescript/src/server_clients/interactive_oauth.ts).
+See a full example as part of the sample chatbot [here](examples/chatbots/typescript/src/interactive_oauth.ts).
 
 </details>
 
@@ -433,7 +433,7 @@ async with streamablehttp_client(
         tool_result = await session.call_tool("echo", {"message": "hello"})
 ```
 
-See a full example as part of the sample chatbot [here](examples/chatbots/python/server_clients/interactive_oauth.py).
+See a full example as part of the sample chatbot [here](examples/chatbots/python/interactive_oauth.py).
 
 </details>
 
@@ -468,7 +468,7 @@ const transport = new StreamableHTTPClientTransport(
 await client.connect(transport);
 ```
 
-See a full example as part of the sample chatbot [here](examples/chatbots/typescript/src/server_clients/interactive_oauth.ts).
+See a full example as part of the sample chatbot [here](examples/chatbots/typescript/src/interactive_oauth.ts).
 
 </details>
 
@@ -586,7 +586,7 @@ async with aws_iam_streamablehttp_client(
         tool_result = await session.call_tool("echo", {"message": "hello"})
 ```
 
-See a full example as part of the sample chatbot [here](examples/chatbots/python/server_clients/lambda_function_url.py).
+See a full example as part of the sample chatbot [here](examples/chatbots/python/mcp_clients.py).
 
 </details>
 
@@ -620,7 +620,7 @@ const transport = new StreamableHTTPClientWithSigV4Transport(
 await client.connect(transport);
 ```
 
-See a full example as part of the sample chatbot [here](examples/chatbots/typescript/src/server_clients/lambda_function_url.ts).
+See a full example as part of the sample chatbot [here](examples/chatbots/typescript/src/mcp_clients.ts).
 
 </details>
 
@@ -719,7 +719,7 @@ async with lambda_function_client(server_params) as (
         tool_result = await session.call_tool("echo", {"message": "hello"})
 ```
 
-See a full example as part of the sample chatbot [here](examples/chatbots/python/server_clients/lambda_function.py).
+See a full example as part of the sample chatbot [here](examples/chatbots/python/mcp_clients.py).
 
 </details>
 
@@ -755,7 +755,7 @@ const transport = new LambdaFunctionClientTransport(serverParams);
 await client.connect(transport);
 ```
 
-See a full example as part of the sample chatbot [here](examples/chatbots/typescript/src/server_clients/lambda_function.ts).
+See a full example as part of the sample chatbot [here](examples/chatbots/typescript/src/mcp_clients.ts).
 
 </details>
 

--- a/examples/servers/eks-mcp/cdk_stack.py
+++ b/examples/servers/eks-mcp/cdk_stack.py
@@ -137,7 +137,6 @@ class LambdaEksMcpServer(Stack):
             entry="function",
             memory_size=2048,
             timeout=Duration.seconds(10),
-            timeout=Duration.seconds(10),
             environment={
                 "LOG_LEVEL": "DEBUG",
                 "FASTMCP_LOG_LEVEL": "ERROR",

--- a/examples/servers/eks-mcp/function/index.py
+++ b/examples/servers/eks-mcp/function/index.py
@@ -38,6 +38,9 @@ def handler(event, context):
         # Get AWS credentials from Lambda execution role
         session = boto3.Session()
         credentials = session.get_credentials()
+        if credentials is None:
+            raise RuntimeError("Unable to retrieve AWS credentials from the execution environment")
+        resolved = credentials.get_frozen_credentials()
 
         # Server configuration with proper StdioServerParameters
         server_params = StdioServerParameters(
@@ -46,9 +49,9 @@ def handler(event, context):
             env={
                 "FASTMCP_LOG_LEVEL": "ERROR",
                 "AWS_DEFAULT_REGION": os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1")),
-                "AWS_ACCESS_KEY_ID": credentials.access_key,
-                "AWS_SECRET_ACCESS_KEY": credentials.secret_key,
-                "AWS_SESSION_TOKEN": credentials.token,
+                "AWS_ACCESS_KEY_ID": resolved.access_key,
+                "AWS_SECRET_ACCESS_KEY": resolved.secret_key,
+                "AWS_SESSION_TOKEN": resolved.token or "",
                 # Set cache and temp directories to writable /tmp location
                 "CACHE_DIR": "/tmp",
                 "TMPDIR": "/tmp"

--- a/src/python/src/mcp_lambda/client/lambda_client.py
+++ b/src/python/src/mcp_lambda/client/lambda_client.py
@@ -88,9 +88,8 @@ async def lambda_function_client(lambda_function: LambdaFunctionParameters):
                                     and function_response["FunctionError"]
                                 ):
                                     raise Exception(
-                                        "Function invoke returned a function error",
-                                        function_response,
-                                        response_payload,
+                                        f"Function invoke returned a function error: "
+                                        f"{function_response.get('FunctionError')} - {response_payload}"
                                     )
 
                                 if response_payload == "{}":

--- a/src/python/src/mcp_lambda/handlers/bedrock_agent_core_gateway_target_handler.py
+++ b/src/python/src/mcp_lambda/handlers/bedrock_agent_core_gateway_target_handler.py
@@ -33,7 +33,7 @@ class BedrockAgentCoreGatewayTargetHandler:
 
         # Gateway names the tools like <target name>___<tool name>
         parts = gateway_tool_name.split("___", 1)
-        if len(parts) != 2:
+        if len(parts) != 2 or not parts[1]:
             raise ValueError(f"Invalid tool name format: {gateway_tool_name}")
         tool_name = parts[1]
 

--- a/src/python/src/mcp_lambda/handlers/streamable_http_handler.py
+++ b/src/python/src/mcp_lambda/handlers/streamable_http_handler.py
@@ -38,7 +38,7 @@ from .request_handler import RequestHandler
 # Set up logging
 logger = logging.getLogger(__name__)
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
-logger.setLevel(getattr(logging, log_level))
+logger.setLevel(getattr(logging, log_level, logging.INFO))
 logger.addHandler(logging.StreamHandler())
 
 # Type variables for generic event and result types

--- a/src/python/src/mcp_lambda/server_adapter/adapter.py
+++ b/src/python/src/mcp_lambda/server_adapter/adapter.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from copy import deepcopy
+from copy import copy
 
 import anyio
 import mcp.types as types
@@ -11,7 +11,7 @@ from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
-logger.setLevel(getattr(logging, log_level))
+logger.setLevel(getattr(logging, log_level, logging.INFO))
 logger.addHandler(logging.StreamHandler())
 
 
@@ -65,7 +65,7 @@ async def handle_json_rpc_notification(server_params, event, context):
 
 async def handle_json_rpc_request(server_params: StdioServerParameters, event, context):
     # Drop the JSON-RPC specific keys
-    request = deepcopy(event)
+    request = copy(event)
     jsonrpc = request.pop("jsonrpc", None)
     id = request.pop("id", None)
 

--- a/src/python/src/mcp_lambda/server_adapter/stdio_server_adapter_request_handler.py
+++ b/src/python/src/mcp_lambda/server_adapter/stdio_server_adapter_request_handler.py
@@ -18,7 +18,7 @@ from .adapter import stdio_server_adapter
 # Set up logging
 logger = logging.getLogger(__name__)
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
-logger.setLevel(getattr(logging, log_level))
+logger.setLevel(getattr(logging, log_level, logging.INFO))
 logger.addHandler(logging.StreamHandler())
 
 

--- a/src/python/tests/test_handlers.py
+++ b/src/python/tests/test_handlers.py
@@ -576,6 +576,22 @@ class TestBedrockAgentCoreGatewayTargetHandler:
         ):
             handler.handle(event, context)
 
+    def test_empty_tool_name_after_delimiter_raises_error(self):
+        """Test that empty tool name after delimiter raises ValueError."""
+        handler = BedrockAgentCoreGatewayTargetHandler(Mock(spec=RequestHandler))
+
+        # Mock context with gateway tool name that has empty tool name after delimiter
+        context = Mock(spec=LambdaContext)
+        context.client_context = Mock()
+        context.client_context.custom = {"bedrockAgentCoreToolName": "target___"}
+
+        event = {"param1": "value1"}
+
+        with pytest.raises(
+            ValueError, match="Invalid tool name format: target___"
+        ):
+            handler.handle(event, context)
+
     def test_multiple_delimiters_in_tool_name(self):
         """Test that tool name with multiple delimiters works correctly."""
         # Create a mock request handler that handles tools/call

--- a/src/typescript/src/handlers/bedrockAgentCoreGatewayTargetHandler.ts
+++ b/src/typescript/src/handlers/bedrockAgentCoreGatewayTargetHandler.ts
@@ -41,6 +41,10 @@ export class BedrockAgentCoreGatewayTargetHandler {
       delimiterIndex + delimiter.length
     );
 
+    if (!toolName) {
+      throw new Error(`Invalid gateway tool name format: ${gatewayToolName}`);
+    }
+
     // Create JSON-RPC request from gateway event
     const jsonRpcRequest: JSONRPCRequest = {
       jsonrpc: "2.0",

--- a/src/typescript/src/handlers/handlers.test.ts
+++ b/src/typescript/src/handlers/handlers.test.ts
@@ -954,6 +954,21 @@ describe("BedrockAgentCoreGatewayTargetHandler", () => {
     ).rejects.toThrow("Invalid gateway tool name format: invalid_format");
   });
 
+  it("should throw error when tool name is empty after delimiter", async () => {
+    const contextWithEmptyToolName = {
+      clientContext: {
+        custom: {
+          bedrockAgentCoreToolName: "target___",
+        },
+      },
+    } as unknown as Context;
+    const event = { param1: "value1" };
+
+    await expect(
+      handler.handle(event, contextWithEmptyToolName)
+    ).rejects.toThrow("Invalid gateway tool name format: target___");
+  });
+
   it("should handle tool name with multiple delimiters", async () => {
     const contextWithMultipleDelimiters = {
       clientContext: {


### PR DESCRIPTION
## Summary

Fixes several high-severity bugs identified during a comprehensive code audit of both the TypeScript and Python implementations.

- **Remove duplicate `timeout` parameter in EKS CDK stack** (`examples/servers/eks-mcp/cdk_stack.py`) — the keyword arg was specified twice, which could cause deployment issues
- **Add null check for AWS credentials in EKS Lambda handler** (`examples/servers/eks-mcp/function/index.py`) — `session.get_credentials()` can return `None` if no IAM role is attached; also uses `get_frozen_credentials()` for thread-safe access and handles missing session token
- **Validate extracted tool name is non-empty in Bedrock gateway handler** (both TS and Python) — a gateway tool name like `"prefix___"` previously resulted in an empty tool name being passed through silently
- **Fix Exception raised with tuple args in Python lambda client** (`src/python/src/mcp_lambda/client/lambda_client.py`) — `Exception("msg", obj1, obj2)` produces an unreadable `str()` representation; now uses an f-string
- **Replace `deepcopy` with shallow `copy` in adapter** (`src/python/src/mcp_lambda/server_adapter/adapter.py`) — only top-level keys (`jsonrpc`, `id`) are popped; `deepcopy` is unnecessarily expensive and can fail on non-copyable objects
- **Add safe fallback for invalid `LOG_LEVEL` env var** (3 Python files) — `getattr(logging, "INVALID_LEVEL")` raises `AttributeError` at module import time, preventing the Lambda function from starting; now falls back to `INFO`
- **Fix 8 broken documentation links in README** — all links to `examples/chatbots/*/server_clients/` pointed to a directory that doesn't exist

## Test plan

- [ ] Verify EKS CDK stack synthesizes without errors (`cdk synth`)
- [ ] Verify existing unit tests pass for both TypeScript and Python
- [ ] Verify Bedrock gateway handler rejects tool names like `"prefix___"` with an error
- [ ] Verify README links resolve to actual files in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)