### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Run Model Context Protocol (MCP) servers with AWS Lambda
 
+[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Frun-model-context-protocol-servers-with-aws-lambda%2Fawslabs.svg)](https://mcptoplist.com/server/mcp.so%2Frun-model-context-protocol-servers-with-aws-lambda%2Fawslabs)
+
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/run-mcp-servers-with-aws-lambda?style=for-the-badge&label=PyPi%20Downloads&color=blue)](https://pypi.org/project/run-mcp-servers-with-aws-lambda/)
 [![NPM Downloads](https://img.shields.io/npm/dm/%40aws%2Frun-mcp-servers-with-aws-lambda?style=for-the-badge&label=NPM%20Downloads&color=blue)](https://www.npmjs.com/package/@aws/run-mcp-servers-with-aws-lambda)
 


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,852 MCP servers across the major
registries, and **Run Model Context Protocol (MCP) servers with AWS Lambda MCP Server** is currently ranked **#727**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Frun-model-context-protocol-servers-with-aws-lambda%2Fawslabs.svg)](https://mcptoplist.com/server/mcp.so%2Frun-model-context-protocol-servers-with-aws-lambda%2Fawslabs)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Run Model Context Protocol (MCP) servers with AWS Lambda MCP Server!
